### PR TITLE
Fix install on darwin

### DIFF
--- a/play_others.go
+++ b/play_others.go
@@ -1,4 +1,4 @@
-// +build !darwin, !windows
+// +build !darwin,!windows
 
 package main
 


### PR DESCRIPTION
ビルド条件を `!darwin AND !windows` にするためにスペースを削除しました。
